### PR TITLE
Inverse scale

### DIFF
--- a/src/gstkaldinnet2onlinedecoder.h
+++ b/src/gstkaldinnet2onlinedecoder.h
@@ -61,6 +61,7 @@ struct _Gstkaldinnet2onlinedecoder {
   gboolean silent;
   gboolean do_endpointing;
   gboolean inverse_scale;
+  float lmwt_scale;
   GstBufferSource *audio_source;
 
   gchar* model_rspecifier;


### PR DESCRIPTION
Hi,

I have added two options for scaling the lattice after decoding: the first normalizes the acoustic scaling done when decoding, and the other gives weight to the LM.  they could be merged together (only the ratio counts), but i thought it is clearer that way.

Anyway, default behavior stays the same :)
