### PR TITLE
add support for threaded nnet2 decoding

### DIFF
--- a/src/gstkaldinnet2onlinedecoder.h
+++ b/src/gstkaldinnet2onlinedecoder.h
@@ -25,7 +25,12 @@
 #include "./simple-options-gst.h"
 #include "./gst-audio-source.h"
 
+#ifdef THREADED_DECODER
+#include "online2/online-nnet2-decoding-threaded.h"
+#else
 #include "online2/online-nnet2-decoding.h"
+#endif
+
 #include "online2/onlinebin-util.h"
 #include "online2/online-timing.h"
 #include "online2/online-endpoint.h"
@@ -72,7 +77,11 @@ struct _Gstkaldinnet2onlinedecoder {
   SimpleOptionsGst *simple_options;
   OnlineEndpointConfig *endpoint_config;
   OnlineNnet2FeaturePipelineConfig *feature_config;
+#ifdef THREADED_DECODER
+  OnlineNnet2DecodingThreadedConfig *nnet2_decoding_config;
+#else
   OnlineNnet2DecodingConfig *nnet2_decoding_config;
+#endif
 
   OnlineNnet2FeaturePipelineInfo *feature_info;
   TransitionModel *trans_model;


### PR DESCRIPTION
recent kaldi version add a new decoder class of threaded processing,
with a different API than the previous (SingleUtteranceNnet2DecoderThreaded
instead of SingleUtteranceNnet2Decoder).

this commit adds compile-time support to the threaded decoder, by
ifdef'ing all the relevant API changes. future commit should make it
prettier, but for now, in order to avoid everybody updating kaldi source
code, this seems better.

compile the threaded decoder with make CPPFLAGS=-DTHREADED_DECODER.

Signed-off-by: Amit Beka <amit.beka@gmail.com>