### PR TITLE
better linker detection

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,13 +39,16 @@ EXTRA_LDLIBS+=-lmkl_p4n -lmkl_def
 endif
 
 # Library so name and rpath
-ifneq (,$(findstring clang++, $(CXX)))
+
+CXX_VERSION=$(shell $(CXX) --version 2>/dev/null)
+ifneq (,$(findstring clang, $(CXX_VERSION)))
     # clang++ linker
     EXTRA_LDLIBS +=  -Wl,-install_name,$(LIBFILE) -Wl,-rpath,$(KALDILIBDIR)
 else
     # g++ linker
     EXTRA_LDLIBS +=  -Wl,-soname=$(LIBFILE) -Wl,--no-as-needed -Wl,-rpath=$(KALDILIBDIR) -lrt -pthread
 endif
+
 
 $(LIBFILE): $(OBJFILES)
 	$(CXX) -shared -DPIC -o $(LIBFILE) -L$(KALDILIBDIR) $(EXTRA_LDLIBS) $(LDLIBS) $(LDFLAGS) \


### PR DESCRIPTION
Better check.

Here on my system CXX was actually equal to g++. However /usr/bin/g++ in my Mac system is a link to clang++

In this patch it runs $(CXX) --version and looks for clang in the output.

Could you try it with your system and see if it still works?
