### PR TITLE
Fix bug dealing with boolean options

### DIFF
--- a/src/gstkaldinnet2onlinedecoder.cc
+++ b/src/gstkaldinnet2onlinedecoder.cc
@@ -516,7 +516,7 @@ static void gst_kaldinnet2onlinedecoder_set_property(GObject * object,
           switch (option_type) {
             case SimpleOptions::kBool:
               filter->simple_options->SetOption(name,
-                                                g_value_get_boolean(value));
+                                                (bool)g_value_get_boolean(value));
               break;
             case SimpleOptions::kInt32:
               filter->simple_options->SetOption(name, g_value_get_int(value));


### PR DESCRIPTION
```g_value_get_boolean``` returns a ```gboolean```, which is actually ```gint```. It causes the ```int``` version of ```SetOption``` is called instead of the correct ```bool``` version one. This causes a problem when boolean option is used, ```add-pitch``` for example.