### PR TITLE
Switch models and graphs

### DIFF
--- a/src/gstkaldinnet2onlinedecoder.cc
+++ b/src/gstkaldinnet2onlinedecoder.cc
@@ -298,6 +298,10 @@ static void gst_kaldinnet2onlinedecoder_init(
   double tmp_double;
   std::string tmp_string;
 
+  filter->trans_model = NULL;
+  filter->nnet = NULL;
+  filter->decode_fst = NULL;
+
   filter->sinkpad = NULL;
 
   filter->sinkpad = gst_pad_new_from_static_template(&sink_template, "sink");
@@ -1092,7 +1096,7 @@ gst_kaldinnet2onlinedecoder_load_model(Gstkaldinnet2onlinedecoder * filter,
                 filter->nnet = new nnet2::AmNnet();
             }
 
-            // Read the new models
+            // Make the objects read the new models
             try {
                 bool binary;
                 Input ki(str, &binary);

--- a/src/gstkaldinnet2onlinedecoder.cc
+++ b/src/gstkaldinnet2onlinedecoder.cc
@@ -1163,24 +1163,6 @@ gst_kaldinnet2onlinedecoder_allocate(
 
   filter->sample_rate = (int) filter->feature_info->mfcc_opts.frame_opts.samp_freq;
 
-  /*
-  if (!filter->trans_model) {
-      filter->trans_model = new TransitionModel();
-      filter->nnet = new nnet2::AmNnet();
-      {
-        bool binary;
-        Input ki(filter->model_rspecifier, &binary);
-        filter->trans_model->Read(ki.Stream(), binary);
-        filter->nnet->Read(ki.Stream(), binary);
-      }
-  }
-
-
-  if (!filter->decode_fst) {
-    filter->decode_fst = fst::ReadFstKaldi(filter->fst_rspecifier);
-  }
-  */
-
   if (!filter->word_syms) {
     if (!(filter->word_syms = fst::SymbolTable::ReadText(
         filter->word_syms_filename))) {

--- a/src/gstkaldinnet2onlinedecoder.cc
+++ b/src/gstkaldinnet2onlinedecoder.cc
@@ -83,7 +83,6 @@ enum {
 #define DEFAULT_MODEL           ""
 #define DEFAULT_FST             ""
 #define DEFAULT_WORD_SYMS       ""
-#define DEFAULT_PHONE_SYMS       ""
 #define DEFAULT_LMWT_SCALE	1.0
 #define DEFAULT_CHUNK_LENGTH_IN_SECS  0.05
 #define DEAFULT_USE_THREADED_DECODER false


### PR DESCRIPTION
This pull requests attempts to resolve issue #4 
Allow switching models and graphs, with simple property changes.

Set the default model, fst, word_syms to empty strings, since all these Kaldi objects get loaded as soon as they are set not in the allocate stage.