### PR TITLE
add nbest-results signal with configurable number of transcriptions

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -24,7 +24,7 @@ EXTRA_LDLIBS += -L$(FSTROOT)/lib -lkaldi-online2 -lkaldi-lat -lkaldi-decoder -lk
  -lkaldi-gmm -lkaldi-hmm \
  -lkaldi-tree -lkaldi-matrix  -lkaldi-util -lkaldi-base -lkaldi-thread -lkaldi-lm -lfstscript -lkaldi-nnet2 -lkaldi-cudamatrix -lkaldi-ivector
 
-OBJFILES = gstkaldinnet2onlinedecoder.o simple-options-gst.o gst-audio-source.o kaldimarshal.o
+OBJFILES = gstkaldinnet2onlinedecoder.o simple-options-gst.o gst-audio-source.o kaldimarshal.o kaldi-result.o
 
 LIBNAME=gstkaldionline2
 

--- a/src/gstkaldinnet2onlinedecoder.h
+++ b/src/gstkaldinnet2onlinedecoder.h
@@ -91,6 +91,7 @@ struct _Gstkaldinnet2onlinedecoder {
   float chunk_length_in_secs;
   float traceback_period_in_secs;
   bool use_threaded_decoder;
+  guint num_nbest;
   OnlineIvectorExtractorAdaptationState *adaptation_state;
 
   // The following are needed for optional LM rescoring with a "big" LM
@@ -107,6 +108,7 @@ struct _Gstkaldinnet2onlinedecoderClass {
   void (*final_result)(GstElement *element, const gchar *result_str);
   void (*partial_phone_alignment)(GstElement *element, const gchar *result_str);
   void (*final_phone_alignment)(GstElement *element, const gchar *result_str);
+  void (*nbest_results)(GstElement *element, const gchar *result_str);
 };
 
 GType gst_kaldinnet2onlinedecoder_get_type(void);

--- a/src/kaldi-result.cc
+++ b/src/kaldi-result.cc
@@ -1,0 +1,105 @@
+// kaldi-result.cc
+
+// Copyright 2015 Amit Beka (amit.beka@gmail.com)
+
+// See ../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include "./kaldi-result.h"
+
+namespace kaldi {
+
+G_DEFINE_TYPE(KaldiResult, kaldi_result, G_TYPE_OBJECT)
+
+enum
+{
+  PROP_0,
+  PROP_TEXTS,
+  N_PROPERTIES
+};
+
+static GParamSpec *obj_properties[N_PROPERTIES] = { NULL, };
+
+static void
+kaldi_result_set_property (GObject *object, guint property_id,
+    const GValue *value, GParamSpec   *pspec)
+{
+  KaldiResult *self = KALDI_RESULT(object);
+
+  switch (property_id)
+  {
+    case PROP_TEXTS:
+      g_free(self->texts);
+      self->texts = g_value_dup_string(value);
+      break;
+
+    default:
+      /* We don't have any other property... */
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+  }
+}
+
+static void
+kaldi_result_get_property (GObject *object, guint property_id,
+    GValue *value, GParamSpec *pspec)
+{
+  KaldiResult *self = KALDI_RESULT(object);
+
+  switch (property_id)
+  {
+    case PROP_TEXTS:
+      g_value_set_string(value, self->texts);
+      break;
+
+    default:
+      /* We don't have any other property... */
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+  }
+}
+
+static void
+kaldi_result_init (KaldiResult *self) {
+  self->texts = NULL;
+}
+
+static void
+kaldi_result_finalize (GObject *gobject) {
+  KaldiResult *self = KALDI_RESULT(gobject);
+  g_free(self->texts);
+  G_OBJECT_CLASS(kaldi_result_parent_class)->finalize(gobject);
+}
+
+
+static void
+kaldi_result_class_init (KaldiResultClass *klass) {
+  GObjectClass *gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = kaldi_result_finalize;
+  gobject_class->set_property = kaldi_result_set_property;
+  gobject_class->get_property = kaldi_result_get_property;
+
+  obj_properties[PROP_TEXTS] =
+    g_param_spec_string ("texts",
+        "transcription texts",
+        "transcriptions texts, separated with newlines",
+        "",
+        G_PARAM_READWRITE);
+
+  g_object_class_install_properties (gobject_class, N_PROPERTIES, obj_properties);
+}
+
+} // namespace kaldi

--- a/src/kaldi-result.h
+++ b/src/kaldi-result.h
@@ -1,0 +1,59 @@
+// kaldi-result.h
+
+// Copyright 2015 Amit Beka (amit.beka@gmail.com)
+
+// See ../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef __KALDI_RESULT_H__
+#define __KALDI_RESULT_H__
+
+#include <glib-object.h>
+
+namespace kaldi {
+
+#define KALDI_TYPE_RESULT                  (kaldi_result_get_type ())
+#define KALDI_RESULT(obj)                  (G_TYPE_CHECK_INSTANCE_CAST ((obj), KALDI_TYPE_RESULT, KaldiResult))
+#define KALDI_IS_RESULT(obj)               (G_TYPE_CHECK_INSTANCE_TYPE ((obj), KALDI_TYPE_RESULT))
+#define KALDI_RESULT_CLASS(klass)          (G_TYPE_CHECK_CLASS_CAST ((klass), KALDI_TYPE_RESULT, KaldiResultClass))
+#define KALDI_IS_RESULT_CLASS(klass)       (G_TYPE_CHECK_CLASS_TYPE ((klass), KALDI_TYPE_RESULT))
+#define KALDI_RESULT_GET_CLASS(obj)        (G_TYPE_INSTANCE_GET_CLASS ((obj), KALDI_TYPE_RESULT, KaldiResultClass))
+
+typedef struct _KaldiResult        KaldiResult;
+typedef struct _KaldiResultClass   KaldiResultClass;
+
+
+struct _KaldiResult
+{
+    /* Parent instance structure */
+    GObject parent_instance;
+
+    /* Transcriptions for all results, separated by newlines */
+    gchar *texts;
+};
+
+struct _KaldiResultClass
+{
+    /* Parent class structure */
+    GObjectClass parent_class;
+};
+
+/* used by KALDI_TYPE_RESULT */
+GType kaldi_result_get_type (void);
+
+} // namespace kaldi
+
+#endif /* __KALDI_RESULT_H__ */


### PR DESCRIPTION
Add the 'nbest-results' signal which enables configurable number of
transcriptions to be returned.

The new signal emits a GObject named KaldiResult, which has a single
property named "texts", which is a newline-delimited string of all the
transcriptions. Other methods of passing variable number of results
(GArray, JSON, GObject with GArray) have failed until now because they
were opaque to PyGTK, or had memory issues, or for unknown reasons.
Passing a configurable GArray of results, or a GObject with dynamic
array of results is prefereable to the current approach, but I couldn't
make it work.

The main filter got a new property, 'num-nbest', which indicates the
number of transcriptions to output in the nbest-results signal. If it is
set to 0 (the default), the signal isn't called. Note that Kaldi can
emit less transcriptions than this number (based on the lattice itself).

Signed-off-by: Amit Beka <amit.beka@gmail.com>