### PR TITLE
Fix malloc/delete to malloc/free; and deprecate variable length array

### DIFF
--- a/src/gst-audio-source.cc
+++ b/src/gst-audio-source.cc
@@ -66,7 +66,7 @@ void GstBufferSource::SetEnded(bool ended) {
 bool GstBufferSource::Read(Vector<BaseFloat> *data) {
   uint32 nsamples_req = data->Dim();  // (16bit) samples requested
   uint32 kDim = data->Dim();
-  int16 buf[kDim];
+  int16 *buf = new int16[kDim];
   uint32 nbytes_transferred = 0;
 
   while ((nbytes_transferred  < nsamples_req * sizeof(SampleType))) {
@@ -106,6 +106,8 @@ bool GstBufferSource::Read(Vector<BaseFloat> *data) {
   for (int i = 0; i < nsamples_received ; ++i) {
     (*data)(i) = static_cast<BaseFloat>(buf[i]);
   }
+
+  delete buf;
 
   if (nsamples_received < nsamples_req) {
     data->Resize(nsamples_received, kCopyData);

--- a/src/gst-audio-source.cc
+++ b/src/gst-audio-source.cc
@@ -107,7 +107,7 @@ bool GstBufferSource::Read(Vector<BaseFloat> *data) {
     (*data)(i) = static_cast<BaseFloat>(buf[i]);
   }
 
-  delete buf;
+  delete[] buf;
 
   if (nsamples_received < nsamples_req) {
     data->Resize(nsamples_received, kCopyData);

--- a/src/gstkaldinnet2onlinedecoder.cc
+++ b/src/gstkaldinnet2onlinedecoder.cc
@@ -664,7 +664,7 @@ static void gst_kaldinnet2onlinedecoder_set_property(GObject * object,
             filter->adaptation_state = new OnlineIvectorExtractorAdaptationState(
                 filter->feature_info->ivector_extractor_info);
           }
-          delete adaptation_state_string;
+		  g_free(adaptation_state_string);
         } else {
           GST_DEBUG_OBJECT(filter, "Resetting adaptation state");
           delete filter->adaptation_state;


### PR DESCRIPTION
1. `g_value_dup_string()` calls `malloc()` internally, so it should correspond to `g_free()` rather than `operator delete()`
2. standard C++ does not support variable length array
3. I made the above changes to get it compiled with Visual C++ because I need it to work on Windows.
4. This is my first time creating a pull request on GitHub. Please correct me if I do anything wrong.