### PR TITLE
Add option to specify number of phone-aligned hypotheses

### DIFF
--- a/src/gstkaldinnet2onlinedecoder.h
+++ b/src/gstkaldinnet2onlinedecoder.h
@@ -106,6 +106,7 @@ struct _Gstkaldinnet2onlinedecoder {
   float traceback_period_in_secs;
   bool use_threaded_decoder;
   guint num_nbest;
+  guint num_phone_alignment;
   guint min_words_for_ivector;
   OnlineIvectorExtractorAdaptationState *adaptation_state;
   float segment_start_time;


### PR DESCRIPTION
Prior to this, setting `do-phone-alignment` to true would result in only the top-rated hypothesis having phone alignment. 

This patch adds a `num-phone-alignment` to specify the maximum number of hypotheses on which to perform phone alignment. Specifying a number of hypotheses greater than the total is therefore harmless.

The `num-phone-alignment` property defaults to `1`, which would keep the current behaviour unchanged.

Any comments are more than welcome.
