### PR TITLE
Update Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -32,7 +32,7 @@ EXTRA_LDLIBS += -lkaldi-online2 -lkaldi-lat -lkaldi-decoder -lkaldi-feat -lkaldi
 
 OBJFILES = gstkaldinnet2onlinedecoder.o simple-options-gst.o gst-audio-source.o kaldimarshal.o
 
-LIBNAME=gstkaldionline2
+LIBNAME=gstkaldinnet2onlinedecoder
 
 LIBFILE = lib$(LIBNAME).so
 BINFILES= $(LIBFILE)


### PR DESCRIPTION
The plugin is not recognised as valid when using the master gstreamer branch because the symname is extracted from the filename, https://github.com/GStreamer/gstreamer/blob/master/gst/gstplugin.c#L685